### PR TITLE
Remove seven_zip dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,6 @@ depends 'ark'
 depends 'database'
 depends 'java'
 depends 'osl-postgresql'
-depends 'seven_zip', '< 3.0.0'
 
 %w{redhat centos}.each do |os|
   supports os


### PR DESCRIPTION
I added crowd to the phpbb environment in chef-repo after merging the Chef 13 fixes, and there is a dependency conflict with the seven_zip cookbook. I don't see any reason why this cookbook restricts seven_zip to < 3.0.0.